### PR TITLE
Release/0.1.5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "crimson-file-loader"
-version = "0.1.4"
+version = "0.1.5"
 description = "Load files in one folder."
 readme = "README.md"
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ classifiers = [
 ]
 dependencies = [
     "pydantic",
+    "crimson-intelli-type==0.4.0"
 ]
 requires-python = ">=3.9"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "crimson-file-loader"
-version = "0.1.3"
+version = "0.1.4"
 description = "Load files in one folder."
 readme = "README.md"
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "crimson-file-loader"
-version = "0.1.2"
+version = "0.1.3"
 description = "Load files in one folder."
 readme = "README.md"
 authors = [

--- a/src/crimson/file_loader/__init__.py
+++ b/src/crimson/file_loader/__init__.py
@@ -1,5 +1,5 @@
 import os
-from typing import Callable, Optional, Generic, TypeVar, List, Tuple
+from typing import Callable, Optional, Generic, TypeVar, List, TypedDict
 from pathlib import Path
 from crimson.intelli_type import IntelliType
 import shutil
@@ -14,6 +14,11 @@ from .utils import (
 )
 
 T = TypeVar("T")
+
+
+class ByteSourceDict(TypedDict):
+    path: str
+    content: bytes
 
 
 class PostPathEditor_(IntelliType[Optional[Callable[[str], str]]], Generic[T]):
@@ -66,12 +71,12 @@ def generate_file_contents(
     excludes: Excludes_.annotation = [],
     post_path_editor: PostPathEditor_.annotation = None,
     search: Search_.annotation = Search_.default,
-) -> List[Tuple[str, bytes]]:
+) -> List[ByteSourceDict]:
     """
     Prepares file information (path and content) from a source directory,
     applies filtering and structure-info-augmented filename.
 
-    Returns a list of tuples, each containing the new file path and its content.
+    Returns a list of SourceDict, each containing the new file path and its content.
     """
     source_paths = filter_source(source, includes, excludes, search=search)
     file_contents = []
@@ -84,7 +89,7 @@ def generate_file_contents(
         with open(src_path, "rb") as f:
             content = f.read()
 
-        file_contents.append((new_path, content))
+        file_contents.append({"path": new_path, "content": content})
 
     return file_contents
 
@@ -112,12 +117,12 @@ def collect_files(
         source, separator, includes, excludes, post_path_editor, search
     )
 
-    for new_path, content in file_contents:
-        full_path = out_dir_path / new_path
+    for item in file_contents:
+        full_path = out_dir_path / item["path"]
         full_path.parent.mkdir(parents=True, exist_ok=True)
 
         with open(full_path, "wb") as f:
-            f.write(content)
+            f.write(item["content"])
 
     print(f"Files collected from {source} to {out_dir}")
 

--- a/src/crimson/file_loader/__init__.py
+++ b/src/crimson/file_loader/__init__.py
@@ -1,6 +1,5 @@
-# src/crimson/file_loader/__init__.py
 import os
-from typing import Callable, Optional, Generic, TypeVar
+from typing import Callable, Optional, Generic, TypeVar, List, Tuple
 from pathlib import Path
 from crimson.intelli_type import IntelliType
 import shutil
@@ -60,6 +59,36 @@ class OutDir_(IntelliType[str], Generic[T]):
     """
 
 
+def generate_file_contents(
+    source: Source_.annotation,
+    separator: Separator_.annotation = "%",
+    includes: Includes_.annotation = [],
+    excludes: Excludes_.annotation = [],
+    post_path_editor: PostPathEditor_.annotation = None,
+    search: Search_.annotation = Search_.default,
+) -> List[Tuple[str, bytes]]:
+    """
+    Prepares file information (path and content) from a source directory,
+    applies filtering and structure-info-augmented filename.
+
+    Returns a list of tuples, each containing the new file path and its content.
+    """
+    source_paths = filter_source(source, includes, excludes, search=search)
+    file_contents = []
+
+    for src_path in source_paths:
+        new_path = transform_path(src_path, separator)
+        if post_path_editor:
+            new_path = post_path_editor(new_path)
+
+        with open(src_path, "rb") as f:
+            content = f.read()
+
+        file_contents.append((new_path, content))
+
+    return file_contents
+
+
 def collect_files(
     source: Source_.annotation,
     out_dir: OutDir_.annotation,
@@ -79,18 +108,16 @@ def collect_files(
         shutil.rmtree(out_dir)
     out_dir_path.mkdir(parents=True, exist_ok=True)
 
-    source_paths = filter_source(source, includes, excludes, search=search)
+    file_contents = generate_file_contents(
+        source, separator, includes, excludes, post_path_editor, search
+    )
 
-    for src_path in source_paths:
+    for new_path, content in file_contents:
+        full_path = out_dir_path / new_path
+        full_path.parent.mkdir(parents=True, exist_ok=True)
 
-        new_path = transform_path(src_path, separator)
-        if post_path_editor:
-            new_path = post_path_editor(new_path)
-        new_path = str(Path(out_dir) / new_path)
-
-        Path(new_path).parent.mkdir(parents=True, exist_ok=True)
-
-        shutil.copy2(src_path, new_path)
+        with open(full_path, "wb") as f:
+            f.write(content)
 
     print(f"Files collected from {source} to {out_dir}")
 

--- a/src/crimson/file_loader/converter.py
+++ b/src/crimson/file_loader/converter.py
@@ -2,9 +2,14 @@ from typing import TypedDict, List, Any
 from . import generate_file_contents, collect_files, ByteSourceDict
 
 
-class SourceDict(TypedDict):
+class StrSourceDict(TypedDict):
     path: str
     content: str
+
+
+class MixedSourceDict(TypedDict):
+    byte_sources: List[ByteSourceDict]
+    str_sources: List[StrSourceDict]
 
 
 def convert_byte_to_str(
@@ -13,11 +18,9 @@ def convert_byte_to_str(
         "generate_fn": generate_file_contents,
         "collect_fn": collect_files,
     },
-) -> List[SourceDict]:
+) -> List[StrSourceDict]:
     """
-    The `generate_fn` returns `List[ByteSourceDict]` instead of `str`.
-    It is for `collect_fn` to create non-textual files as well.
-    In order to convert the byte data simply, this helper function is added.
+    Converts the byte content in ByteSourceDict to string content.
 
     For the information of `generate_fn` and `collect_fn`,
     check the reference arg dummy.
@@ -27,3 +30,32 @@ def convert_byte_to_str(
     for item in sources:
         output.append({"path": item["path"], "content": item["content"].decode("utf-8")})
     return output
+
+
+def convert_textual_byte_to_str(
+    sources: List[ByteSourceDict]
+) -> MixedSourceDict:
+    """
+    Converts the byte content in ByteSourceDict to string content if it's textual
+    and separates them into byte_sources and str_sources.
+
+    Returns a MixedSourceDict with:
+    - "byte_sources": List of ByteSourceDict
+    - "str_sources": List of StrSourceDict
+    """
+    byte_sources: List[ByteSourceDict] = []
+    str_sources: List[StrSourceDict] = []
+
+    for item in sources:
+        try:
+            # Attempt to decode the byte content
+            decoded_content = item["content"].decode("utf-8")
+            str_sources.append({"path": item["path"], "content": decoded_content})
+        except UnicodeDecodeError:
+            # If it fails, keep it as ByteSourceDict
+            byte_sources.append(item)
+
+    return MixedSourceDict(
+        byte_sources=byte_sources,
+        str_sources=str_sources
+    )

--- a/src/crimson/file_loader/converter.py
+++ b/src/crimson/file_loader/converter.py
@@ -1,0 +1,29 @@
+from typing import TypedDict, List, Any
+from . import generate_file_contents, collect_files, ByteSourceDict
+
+
+class SourceDict(TypedDict):
+    path: str
+    content: str
+
+
+def convert_byte_to_str(
+    sources: List[ByteSourceDict],
+    reference: Any = {
+        "generate_fn": generate_file_contents,
+        "collect_fn": collect_files,
+    },
+) -> List[SourceDict]:
+    """
+    The `generate_fn` returns `List[ByteSourceDict]` instead of `str`.
+    It is for `collect_fn` to create non-textual files as well.
+    In order to convert the byte data simply, this helper function is added.
+
+    For the information of `generate_fn` and `collect_fn`,
+    check the reference arg dummy.
+    """
+    output = []
+
+    for item in sources:
+        output.append({"path": item["path"], "content": item["content"].decode("utf-8")})
+    return output

--- a/test/test_converter.py
+++ b/test/test_converter.py
@@ -1,0 +1,41 @@
+import pytest
+from crimson.file_loader.converter import convert_byte_to_str
+
+
+@pytest.fixture
+def byte_sources():
+    return [
+        {"path": "file1.txt", "content": b"Hello World"},
+        {"path": "file2.txt", "content": b"Python Testing"},
+    ]
+
+
+def test_convert_byte_to_str(byte_sources):
+    # Call the convert_byte_to_str function
+    converted_sources = convert_byte_to_str(byte_sources)
+
+    # Expected output after conversion
+    expected_sources = [
+        {"path": "file1.txt", "content": "Hello World"},
+        {"path": "file2.txt", "content": "Python Testing"},
+    ]
+
+    # Assert that the conversion was correct
+    assert converted_sources == expected_sources
+
+
+def test_empty_content():
+    # Test with empty content
+    byte_sources = [{"path": "empty.txt", "content": b""}]
+    converted_sources = convert_byte_to_str(byte_sources)
+
+    expected_sources = [{"path": "empty.txt", "content": ""}]
+    assert converted_sources == expected_sources
+
+
+def test_non_utf8_content():
+    # Test with non-UTF-8 content, should raise UnicodeDecodeError
+    byte_sources = [{"path": "binary.bin", "content": b"\x80\x81\x82"}]
+
+    with pytest.raises(UnicodeDecodeError):
+        convert_byte_to_str(byte_sources)

--- a/test/test_converter.py
+++ b/test/test_converter.py
@@ -1,5 +1,8 @@
 import pytest
-from crimson.file_loader.converter import convert_byte_to_str
+from crimson.file_loader.converter import (
+    convert_byte_to_str,
+    convert_textual_byte_to_str,
+)
 
 
 @pytest.fixture
@@ -7,6 +10,15 @@ def byte_sources():
     return [
         {"path": "file1.txt", "content": b"Hello World"},
         {"path": "file2.txt", "content": b"Python Testing"},
+    ]
+
+
+@pytest.fixture
+def mixed_sources():
+    return [
+        {"path": "file1.txt", "content": b"Hello World"},
+        {"path": "file2.txt", "content": b"Python Testing"},
+        {"path": "binary.bin", "content": b"\x80\x81\x82"}  # Non-UTF-8 content
     ]
 
 
@@ -39,3 +51,51 @@ def test_non_utf8_content():
 
     with pytest.raises(UnicodeDecodeError):
         convert_byte_to_str(byte_sources)
+
+
+def test_convert_textual_byte_to_str(mixed_sources):
+    # Call the convert_textual_byte_to_str function
+    result = convert_textual_byte_to_str(mixed_sources)
+
+    # Expected output
+    expected_byte_sources = [
+        {"path": "binary.bin", "content": b"\x80\x81\x82"}
+    ]
+    expected_str_sources = [
+        {"path": "file1.txt", "content": "Hello World"},
+        {"path": "file2.txt", "content": "Python Testing"},
+    ]
+
+    # Assert that the byte_sources and str_sources are correctly separated and converted
+    assert result["byte_sources"] == expected_byte_sources
+    assert result["str_sources"] == expected_str_sources
+
+
+def test_convert_textual_byte_to_str_with_empty():
+    # Test with empty content in a mixed source list
+    sources = [
+        {"path": "empty.txt", "content": b""},
+        {"path": "file1.txt", "content": b"Hello World"}
+    ]
+    result = convert_textual_byte_to_str(sources)
+
+    expected_byte_sources = []
+    expected_str_sources = [
+        {"path": "empty.txt", "content": ""},
+        {"path": "file1.txt", "content": "Hello World"}
+    ]
+
+    assert result["byte_sources"] == expected_byte_sources
+    assert result["str_sources"] == expected_str_sources
+
+
+def test_convert_textual_byte_to_str_only_non_utf8():
+    # Test with only non-UTF-8 content
+    sources = [{"path": "binary.bin", "content": b"\x80\x81\x82"}]
+    result = convert_textual_byte_to_str(sources)
+
+    expected_byte_sources = [{"path": "binary.bin", "content": b"\x80\x81\x82"}]
+    expected_str_sources = []
+
+    assert result["byte_sources"] == expected_byte_sources
+    assert result["str_sources"] == expected_str_sources

--- a/test/test_init.py
+++ b/test/test_init.py
@@ -114,13 +114,13 @@ def test_reconstruct_folder_structure_overwrite(sample_directory, tmp_path):
 def test_generate_file_contents(sample_directory):
     file_contents = generate_file_contents(
         str(sample_directory),
-        includes=["\.txt$", "\.py$"],
+        includes=[r"\.txt$", r"\.py$"],
         excludes=["dir2"],
     )
 
     assert len(file_contents) == 1
-    assert file_contents[0][0].endswith("dir1%file1.txt")
-    assert file_contents[0][1] == b"content1"
+    assert file_contents[0]["path"].endswith("dir1%file1.txt")
+    assert file_contents[0]["content"] == b"content1"
 
 
 def test_generate_file_contents_with_path_editor(sample_directory):
@@ -132,26 +132,26 @@ def test_generate_file_contents_with_path_editor(sample_directory):
         post_path_editor=path_editor,
     )
 
-    assert any(content[0].endswith("new_dir1%file1.txt") for content in file_contents)
+    assert any(content["path"].endswith("new_dir1%file1.txt") for content in file_contents)
 
 
 def test_generate_file_contents_all_files(sample_directory):
     file_contents = generate_file_contents(str(sample_directory))
 
     assert len(file_contents) == 3
-    file_names = [content[0] for content in file_contents]
+    file_names = [content["path"] for content in file_contents]
     assert any("dir1%file1.txt" in name for name in file_names)
     assert any("dir2%file2.py" in name for name in file_names)
     assert any("file3.jpg" in name for name in file_names)
 
 
 def test_generate_file_contents_binary_content(sample_directory):
-    # 바이너리 파일 생성
+    # Create a binary file
     binary_file = sample_directory / "binary_file.bin"
     binary_file.write_bytes(b'\x00\x01\x02\x03')
 
     file_contents = generate_file_contents(str(sample_directory), includes=[r"\.bin$"])
 
     assert len(file_contents) == 1
-    assert file_contents[0][0].endswith("binary_file.bin")
-    assert file_contents[0][1] == b'\x00\x01\x02\x03'
+    assert file_contents[0]["path"].endswith("binary_file.bin")
+    assert file_contents[0]["content"] == b'\x00\x01\x02\x03'


### PR DESCRIPTION
added a safer converter

```python

def convert_textual_byte_to_str(
    sources: List[ByteSourceDict]
) -> MixedSourceDict:
    """
    Converts the byte content in ByteSourceDict to string content if it's textual
    and separates them into byte_sources and str_sources.

    Returns a MixedSourceDict with:
    - "byte_sources": List of ByteSourceDict
    - "str_sources": List of StrSourceDict
    """
    byte_sources: List[ByteSourceDict] = []
    str_sources: List[StrSourceDict] = []

    for item in sources:
        try:
            # Attempt to decode the byte content
            decoded_content = item["content"].decode("utf-8")
            str_sources.append({"path": item["path"], "content": decoded_content})
        except UnicodeDecodeError:
            # If it fails, keep it as ByteSourceDict
            byte_sources.append(item)

    return MixedSourceDict(
        byte_sources=byte_sources,
        str_sources=str_sources
    )
```